### PR TITLE
.bat, bat, table

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.js
+++ b/code/game/objects/items/stacks/sheets/sheet_types.js
@@ -116,7 +116,8 @@ WoodSheet.template = {
 				merge_type: "WoodSheet",
 				novariants: true,
 				recipes: [
-					{name: "wood floor tiles", template_name: "wood_tile", cost: 1, res_amount: 4, time: 2000}
+					{name: "wood floor tiles", template_name: "wood_tile", cost: 1, res_amount: 4, time: 2000},
+					{name: "baseball bat", template_name: "baseball_bat", cost: 5, time: 1500}
 				]
 			},
 			"Item": { //Wood apparently has no inhands.

--- a/code/game/objects/items/weaponry.js
+++ b/code/game/objects/items/weaponry.js
@@ -17,10 +17,12 @@ BaseballBat.template = {
 				inhand_lhand_icon: 'icons/mob/inhands/weapons/melee_lefthand.dmi',
 				inhand_rhand_icon: 'icons/mob/inhands/weapons/melee_righthand.dmi',
 				inhand_icon_state: "baseball_bat",
-				size: 4,
+				size: 5,
 				force: 10,
-				throw_force: 12,
 				attack_verb: ["beat", "smacked"]
+			},
+			"Tangible": {
+				throw_force: 12
 			},
 			"Examine": {
 				desc: "There ain't a skull in the league that can withstand a swatter."

--- a/code/game/objects/items/weaponry.js
+++ b/code/game/objects/items/weaponry.js
@@ -1,0 +1,42 @@
+'use strict';
+const {Component} = require('bluespess');
+
+class BaseballBat extends Component {
+	constructor(atom, template) {
+		super(atom, template);
+	}
+}
+
+BaseballBat.depends = ["Item"];
+BaseballBat.loadBefore = ["Item"];
+
+BaseballBat.template = {
+	vars: {
+		components: {
+			"Item": {
+				inhand_lhand_icon: 'icons/mob/inhands/weapons/melee_lefthand.dmi',
+				inhand_rhand_icon: 'icons/mob/inhands/weapons/melee_righthand.dmi',
+				inhand_icon_state: "baseball_bat",
+				size: 4,
+				force: 10,
+				throw_force: 12,
+				attack_verb: ["beat", "smacked"]
+			},
+			"Examine": {
+				desc: "There ain't a skull in the league that can withstand a swatter."
+			}
+		},
+		icon: 'icons/obj/items_and_weapons.png',
+		icon_state: 'baseball_bat',
+		name: "baseball bat"
+	}
+};
+
+module.exports.templates = {
+	"baseball_bat": {
+		components: ["BaseballBat"],
+		tree_paths: ["items/melee/baseball_bat"]
+	}
+};
+
+module.exports.components = {BaseballBat};

--- a/code/game/objects/structures/table.js
+++ b/code/game/objects/structures/table.js
@@ -91,6 +91,31 @@ module.exports.templates = {
 			icon_state: "wood_table"
 		},
 		tree_paths: ["basic_structures/table/wood"]
+	},
+	"reinforced_table": {
+		components: ["TGSmooth", "Table"],
+		vars: {
+			components: {
+				"Smooth": {
+					smooth_with: "table_reinforced"
+				},
+				"SmoothGroup": {
+					groups: ["table_reinforced"]
+				},
+				"Destructible": {
+					max_integrity: 200,
+					integrity_failure: 50,
+					armor: {"melee": 10, "bullet": 30, "laser": 30, "energy": 100, "bomb": 20, "bio": 0, "rad": 0, "fire": 80, "acid": 70}
+				},
+				"Examine": {
+					desc: "A reinforced version of the four legged table."
+				}
+			},
+			name: "reinforced table",
+			icon: 'icons/obj/smooth_structures/reinforced_table.png',
+			icon_state: "r_table"
+		},
+		tree_paths: ["basic_structures/table/reinforced"]
 	}
 };
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ server.importModule(require('./code/game/objects/items/clothing.js'));
 server.importModule(require('./code/game/objects/items/emag.js'));
 server.importModule(require('./code/game/objects/items/storage.js'));
 server.importModule(require('./code/game/objects/items/tools.js'));
+server.importModule(require('./code/game/objects/items/weaponry.js'));
 server.importModule(require('./code/game/objects/structures/crates_lockers/base.js'));
 server.importModule(require('./code/game/objects/structures/crates_lockers/closets.js'));
 server.importModule(require('./code/game/objects/structures/crates_lockers/closets/utility.js'));

--- a/launch.bat
+++ b/launch.bat
@@ -1,0 +1,7 @@
+@echo off
+
+title Bluespess
+
+node index.js
+
+pause

--- a/launch_debug.bat
+++ b/launch_debug.bat
@@ -1,0 +1,7 @@
+@echo off
+
+title Bluespess Debug
+
+node --inspect index.js
+
+pause

--- a/tools/map-converter/rules.js
+++ b/tools/map-converter/rules.js
@@ -73,6 +73,7 @@ let rules = [
 	}],
 	["/obj/structure/table", () => {return {template_name: "table"};}],
 	["/obj/structure/table/wood", () => {return {template_name: "wood_table"};}],
+	["/obj/structure/table/reinforced", () => {return {template_name: "reinforced_table"};}],
 
 	["/obj/structure/closet", () => {return {template_name: "closet"};}],
 	["/obj/structure/closet/emcloset", () => {return {template_name: "emergency_closet"};}],
@@ -89,6 +90,10 @@ let rules = [
 	["/obj/item/weldingtool", () => {return {template_name: "weldingtool"};}, {pixel_offsets: true}],
 	["/obj/item/wirecutters", () => {return {template_name: "wirecutters"};}, {pixel_offsets: true}],
 	["/obj/item/wrench", () => {return {template_name: "wrench"};}, {pixel_offsets: true}],
+
+	// WEAPONS
+	
+	["/obj/item/melee/baseball_bat", () => {return {template_name: "baseball_bat"};}, {pixel_offsets: true}],
 
 	// LAMPS AND LIGHTS
 


### PR DESCRIPTION
Adds launch.bat, baseball bats, and reinforced tables.

Clicking launch.bat is slightly easier than typing `node index.js`.
I don't think there's a way to get wood for baseball bats, but my next PR should solve that.
I was tired of looking at normal tables where reinforced tables would be.

![image](https://user-images.githubusercontent.com/5714543/38277929-c4823828-375f-11e8-9efe-b499a57b7749.png)
