### PR TITLE
Updates mop text

### DIFF
--- a/code/modules/janitorial/mop.js
+++ b/code/modules/janitorial/mop.js
@@ -13,7 +13,7 @@ class Mop extends Component {
 
 		if(has_component(target, "OpenReagentContainer")) {
 			if(target.c.ReagentHolder.total_volume < 1)
-				to_chat`<span class='warning'>The ${target} is out of water!</span>`(user);
+				to_chat`<span class='warning'>The ${target} is empty!</span>`(user);
 			else {
 				target.c.ReagentHolder.transfer_to(this.a, 5);
 				to_chat`<span class='warning'>You wet the ${this.a} in the ${target}</span>`(user);


### PR DESCRIPTION
When you interacted with an empty reagent container with a mop, it used to say that the container was empty of water.
The container might not always contain just water, this clarifies that the container is empty and not just out of water, especially since the mop doesn't check for water anyway.

Used to say:
The ${target} is out of water!

Now says:
The ${target} is empty!